### PR TITLE
3 implementing measurement operator

### DIFF
--- a/src/qc_ncsa.aplf
+++ b/src/qc_ncsa.aplf
@@ -12,7 +12,7 @@
         ⍝ Ground state |0>
         q0 ← 2 1 ⍴ 1 0
 
-        ⍝ Excited state |1>
+        ⍝ excitedited state |1>
         q1 ← 2 1 ⍴ 0 1
 
         ⍝ Bloch state
@@ -177,23 +177,23 @@
 
         ⍝ Helper function used in measure_qubit. Splits an list of continuos numbers representing indeces between the ground and excited indeces.
         ⍝ First right argument should be the numbers of items in each state before it switches to the next state.
-        ⍝    e.g.: for a 3 qubit vector state if measuring qubit 0, split_size is 4, qubit 1 split_size is 2 and qubit 3 split_size is 1.
+        ⍝    e.g.: for a 3 qubit vector state if measuring qubit 0, switch is 4, qubit 1 switch is 2 and qubit 3 switch is 1.
         ⍝ Second right argument Array of indices we want to split, should be a power of 2
         ⍝ Third and Fourth arguments are only necessary for recursion, should probably have a default of ⍬
-        ⍝ Returns split_size, empty array, the ground indeces and excited indices.
+        ⍝ Returns switch, empty array, the ground indeces and excited indices.
         _split ← {
-            split_size←⍵[1]
-            indices_to_split←⊃⍵[2]
-            grd←⊃⍵[3]
-            exc←⊃⍵[4]
+            switch←⍵[1]
+            indices←⊃⍵[2]
+            ground←⊃⍵[3]
+            excited←⊃⍵[4]
         
-            grd←grd,(split_size↑indices_to_split)
-            indices_to_split←split_size↓indices_to_split
-            exc←exc,(split_size↑indices_to_split)
-            indices_to_split←split_size↓indices_to_split
+            ground←ground,(switch↑indices)
+            indices←switch↓indices
+            excited←excited,(switch↑indices)
+            indices←switch↓indices
         
-            (⍴indices_to_split)=0:split_size indices_to_split grd exc
-            ∇ split_size indices_to_split grd exc
+            (⍴indices)=0:switch indices ground excited
+            ∇ switch indices ground excited
         }
 
         ⍝ Measures a specific qubit in a threaded register.
@@ -205,15 +205,15 @@
             n_qubits←2⍟n_basis
             a←⍺+1
         
-            split_size←⊃(n_basis÷(2*a))
-            indices_to_split←⍳n_basis
-            _ _ grnd exc←_split((split_size)(indices_to_split)(⍬)(⍬))
+            switch←⊃(n_basis÷(2*a))
+            indices←⍳n_basis
+            _ _ ground excited←_split((switch)(indices)(⍬)(⍬))
         
-            vs←(⊂⍵[grnd;]),(⊂⍵[exc;])
-            grnd_prob←+/(⍉⍵[grnd;]*2)
-            exc_prob←+/(⍉⍵[exc;]*2)
+            vs←(⊂⍵[ground;]),(⊂⍵[excited;])
+            ground_prob←+/(⍉⍵[ground;]*2)
+            excited_prob←+/(⍉⍵[excited;]*2)
         
-            meas_result←1++/(?0)>+\((⊃grnd_prob),(⊃exc_prob))
+            meas_result←1++/(?0)>+\((⊃ground_prob),(⊃excited_prob))
             normed_vs←#.quapl.mlt.normalize(⊃vs[meas_result])
         
             (meas_result-1)(normed_vs)

--- a/src/qc_ncsa.aplf
+++ b/src/qc_ncsa.aplf
@@ -163,6 +163,19 @@
 
     :EndNamespace
 
+    :Namespace Measurement
+        ⍝ Rolls over a set of probabilities. ⍵ should be a vector where each element indicates the probability of the vector to be in that state
+        ⍝ Returns the index of the roll
+        roll ← {1++/(?0)>+\⍵}
+
+        ⍝ Measures a vector space, returns the index of the state that was rolled. (the result will)
+        measure ← {roll (⍉⍵*2)}        
+
+        ⍝ Measures a register.
+        measure_reg ← {measure thread_reg ⍵}
+
+    :EndNamespace
+
     ⍝ Circuit assembly
     :Namespace circuit
         

--- a/src/qc_ncsa.aplf
+++ b/src/qc_ncsa.aplf
@@ -174,6 +174,42 @@
         ⍝ Measures a register.
         measure_reg ← {measure thread_reg ⍵}
 
+         split←{
+            switch←⍵[1]
+            index←⊃⍵[2]
+            grd←⊃⍵[3]
+            exc←⊃⍵[4]
+
+            grd←grd,(switch↑index)
+            index←switch↓index
+            exc←exc,(switch↑index)
+            index←switch↓index
+
+            (⍴index)=0:switch index grd exc
+            ∇ switch index grd exc
+        }
+
+         measure_qubit←{
+            ⍝ ⍺ is the qubit I want to measure
+            ⍝ ⍵ is my thread_reg
+            n_basis←1↑⍴⍵
+            n_qubits←2⍟n_basis
+            a←⍺+1
+
+            switch←⊃(n_basis÷(2*a))
+            index←⍳n_basis
+            _ _ grnd exc←split((switch)(index)(⍬)(⍬))
+
+            vs←(⊂⍵[grnd;]),(⊂⍵[exc;])
+            grnd_prob←+/(⍉⍵[grnd;]*2)
+            exc_prob←+/(⍉⍵[exc;]*2)
+
+            meas_result←1++/(?0)>+\((⊃grnd_prob),(⊃exc_prob))
+            normed_vs←# quapl.mlt.normalize(⊃vs[meas_result])
+
+            (meas_result-1)(normed_vs)
+        }
+
     :EndNamespace
 
     ⍝ Circuit assembly

--- a/src/qc_ncsa.aplf
+++ b/src/qc_ncsa.aplf
@@ -12,7 +12,7 @@
         ⍝ Ground state |0>
         q0 ← 2 1 ⍴ 1 0
 
-        ⍝ excitedited state |1>
+        ⍝ Excited state |1>
         q1 ← 2 1 ⍴ 0 1
 
         ⍝ Bloch state

--- a/src/qc_ncsa.aplf
+++ b/src/qc_ncsa.aplf
@@ -163,50 +163,59 @@
 
     :EndNamespace
 
-    :Namespace Measurement
+    ⍝ Measurement functions
+    :Namespace measure
         ⍝ Rolls over a set of probabilities. ⍵ should be a vector where each element indicates the probability of the vector to be in that state
         ⍝ Returns the index of the roll
         roll ← {1++/(?0)>+\⍵}
 
         ⍝ Measures a vector space, returns the index of the state that was rolled. (the result will)
-        measure ← {roll (⍉⍵*2)}        
+        measure ← {roll (⍉⍵*2)}
 
         ⍝ Measures a register.
-        measure_reg ← {measure thread_reg ⍵}
+        measure_reg ← {measure #.quapl.circuit.thread_reg ⍵}
 
-         split←{
-            switch←⍵[1]
-            index←⊃⍵[2]
+        ⍝ Helper function used in measure_qubit. Splits an list of continuos numbers representing indeces between the ground and excited indeces.
+        ⍝ First right argument should be the numbers of items in each state before it switches to the next state.
+        ⍝    e.g.: for a 3 qubit vector state if measuring qubit 0, split_size is 4, qubit 1 split_size is 2 and qubit 3 split_size is 1.
+        ⍝ Second right argument Array of indices we want to split, should be a power of 2
+        ⍝ Third and Fourth arguments are only necessary for recursion, should probably have a default of ⍬
+        ⍝ Returns split_size, empty array, the ground indeces and excited indices.
+        _split ← {
+            split_size←⍵[1]
+            indices_to_split←⊃⍵[2]
             grd←⊃⍵[3]
             exc←⊃⍵[4]
-
-            grd←grd,(switch↑index)
-            index←switch↓index
-            exc←exc,(switch↑index)
-            index←switch↓index
-
-            (⍴index)=0:switch index grd exc
-            ∇ switch index grd exc
+        
+            grd←grd,(split_size↑indices_to_split)
+            indices_to_split←split_size↓indices_to_split
+            exc←exc,(split_size↑indices_to_split)
+            indices_to_split←split_size↓indices_to_split
+        
+            (⍴indices_to_split)=0:split_size indices_to_split grd exc
+            ∇ split_size indices_to_split grd exc
         }
 
-         measure_qubit←{
-            ⍝ ⍺ is the qubit I want to measure
-            ⍝ ⍵ is my thread_reg
+        ⍝ Measures a specific qubit in a threaded register.
+        ⍝ Returns the measured state of the qubit and the new vector state of the remaining normalized vector state of the other qubits.
+        ⍝ ⍺ is the qubit I want to measure.
+        ⍝ ⍵ is my threadeaded register.
+        measure_qubit ← {
             n_basis←1↑⍴⍵
             n_qubits←2⍟n_basis
             a←⍺+1
-
-            switch←⊃(n_basis÷(2*a))
-            index←⍳n_basis
-            _ _ grnd exc←split((switch)(index)(⍬)(⍬))
-
+        
+            split_size←⊃(n_basis÷(2*a))
+            indices_to_split←⍳n_basis
+            _ _ grnd exc←_split((split_size)(indices_to_split)(⍬)(⍬))
+        
             vs←(⊂⍵[grnd;]),(⊂⍵[exc;])
             grnd_prob←+/(⍉⍵[grnd;]*2)
             exc_prob←+/(⍉⍵[exc;]*2)
-
+        
             meas_result←1++/(?0)>+\((⊃grnd_prob),(⊃exc_prob))
-            normed_vs←# quapl.mlt.normalize(⊃vs[meas_result])
-
+            normed_vs←#.quapl.mlt.normalize(⊃vs[meas_result])
+        
             (meas_result-1)(normed_vs)
         }
 


### PR DESCRIPTION
5 new functions are being added, 2 are helper functions with 3 that might have possible uses.

If you have a normalized vector space and want to measure all of the qubits at once, you can use the measure function. This will return the index of the resulting state in the basis of the original vector space.

measure_reg works in the same way but you should pass a register instead of a vector space.

measure_qubit is used to measure a specific qubit in a vector space. It needs the index (starting at 0) of the qubit we want to measure as a left argument and the vector space in which we want to measure as a right argument. The function returns 2 items, the first being the result of the qubit that measured and the second the new normalized vector state without that qubit in it.