### PR TITLE
Implement the quantum fourier transform

### DIFF
--- a/APLSource/lib/_QFT_.aplf
+++ b/APLSource/lib/_QFT_.aplf
@@ -8,10 +8,11 @@ _QFT_ ← {
 
      stage ← #.quapl.circuit.stage
      H ← #.quapl.gates.H
-     swap ← #.quapl.gates.SWAP
+     SWAP ← #.quapl.gates.SWAP
+     Rz ← #.quapl.gates.Rz
      
      ⍝ Rotation in z multiplied by phase factor to match literature
-     Rz2 ← {(*0J1×⍵÷2) × #.quapl.gates.Rz ⍵}
+     Rz2 ← {(*0J1×⍵÷2) × Rz ⍵}
      
      ⍝ Rotation in z by 2 Pi / 2 ^ ⍵
      Rzn ← {Rz2 ○2÷2*⍵}
@@ -25,41 +26,19 @@ _QFT_ ← {
      ⍝ Applies the Hadamard gate then rotates qubit about z
      ⍝ Indices on left-hand side are reduced by 1, since qubit numbering starts from 0
      lane ← {((⍵-1),((⍵-1)+⍳n_qubits-⍵),¨(⍵-1))((⊂H), CRzn¨ 1+⍳n_qubits-⍵)}
-
      
-
      ⍝ Successively apply the gates of a circuit
-     stage_all ← {
-         ids gts ← ⍺
-          
-         id ← 1↑ids
-         ids ← 1↓ids
-          
-         gate ← 1↑gts
-         gts ← 1↓gts
-         
-         ret ← ((⊃id)(gate)) stage ⍵ 
-         
-         (⍴ids)=0: ret
-         (ids gts) ∇ ret
-     }
+     stage_all ← { ⊃ stage / (⌽⊃⍺[1]{⍺ (⊂⍵)}¨¨⍺[2]),⊂⍵ }
 
      ⍝ Apply the above circuit to qubits from 1 to n_qubits successively
-     apply ← {
-         x ← 1↑⍺
-         a ← 1↓⍺
-         
-         ret ← (lane x) stage_all ⍵
-         (⍴a)=0: ret
-         a ∇ ret
-     }
+     apply ← { ⊃stage_all / (⌽lane¨⍺),⊂⍵ }  
 
      ⍝ Result before swapping
      intermediate ← (⍳n_qubits) apply ⍵
 
      ⍝ Circuit to swap qubits
      ⍝ Indices on left-hand side are reduced by 1, since qubit numbering starts from 0
-     swap_circuit ← (1-⍨(⌊n_qubits÷2)↑(⌽⍳n_qubits),¨⍳n_qubits)({swap}¨⍳⌊n_qubits÷2)
+     swap_circuit ← (1-⍨(⌊n_qubits÷2)↑(⌽⍳n_qubits),¨⍳n_qubits)({SWAP}¨⍳⌊n_qubits÷2)
      
      ⍝ Check if swap circuit is non-empty
      (0=⍴1⌷↑swap_circuit): intermediate

--- a/APLSource/lib/_QFT_.aplf
+++ b/APLSource/lib/_QFT_.aplf
@@ -1,0 +1,68 @@
+_QFT_ ← {
+     ⍝ Quantum Fourier Transform
+     ⍝ Takes a vector state of an n-qubit system
+     ⍝ Returns the n-qubit quantum fourier transform for the vector state
+     ⍝ Uses the product representation of the Quantum Fourier Transform
+     ⍝
+     ⍝ ⍵: Vector state to be transformed
+
+     stage ← #.quapl.circuit.stage
+     H ← #.quapl.gates.H
+     swap ← #.quapl.gates.SWAP
+     
+     ⍝ Rotation in z multiplied by phase factor to match literature
+     Rz2 ← {(*0J1×⍵÷2) × #.quapl.gates.Rz ⍵}
+     
+     ⍝ Rotation in z by 2 Pi / 2 ^ ⍵
+     Rzn ← {Rz2 ○2÷2*⍵}
+
+     ⍝ Controlled form of above rotation
+     CRzn ← 1 #.quapl.gates.gCTR Rzn
+
+     n_qubits ← 2⍟1⌷⍴⍵
+
+     ⍝ Create part of circuit that affects qubit ⍵
+     ⍝ Applies the Hadamard gate then rotates qubit about z
+     ⍝ Indices on left-hand side are reduced by 1, since qubit numbering starts from 0
+     lane ← {((⍵-1),((⍵-1)+⍳n_qubits-⍵),¨(⍵-1))((⊂H), CRzn¨ 1+⍳n_qubits-⍵)}
+
+     
+
+     ⍝ Successively apply the gates of a circuit
+     stage_all ← {
+         ids gts ← ⍺
+          
+         id ← 1↑ids
+         ids ← 1↓ids
+          
+         gate ← 1↑gts
+         gts ← 1↓gts
+         
+         ret ← ((⊃id)(gate)) stage ⍵ 
+         
+         (⍴ids)=0: ret
+         (ids gts) ∇ ret
+     }
+
+     ⍝ Apply the above circuit to qubits from 1 to n_qubits successively
+     apply ← {
+         x ← 1↑⍺
+         a ← 1↓⍺
+         
+         ret ← (lane x) stage_all ⍵
+         (⍴a)=0: ret
+         a ∇ ret
+     }
+
+     ⍝ Result before swapping
+     intermediate ← (⍳n_qubits) apply ⍵
+
+     ⍝ Circuit to swap qubits
+     ⍝ Indices on left-hand side are reduced by 1, since qubit numbering starts from 0
+     swap_circuit ← (1-⍨(⌊n_qubits÷2)↑(⌽⍳n_qubits),¨⍳n_qubits)({swap}¨⍳⌊n_qubits÷2)
+     
+     ⍝ Check if swap circuit is non-empty
+     (0=⍴1⌷↑swap_circuit): intermediate
+
+     swap_circuit stage_all intermediate
+}

--- a/APLSource/mlt.apln
+++ b/APLSource/mlt.apln
@@ -4,6 +4,9 @@
     ⍝ Normalize a quantum state
     normalize ← {⍵÷0.5*⍨(dagger+.×⊢)⍵}
 
+    ⍝ Create all basis states for ⍵ qubits
+    basis ← {{((⍴⍵),1)⍴⍵}¨↓↑1,⍨¨0/⍨¨1-⍨⍳⍵}
+
     ⍝ Test that we have a valid qubit
     valid ← {
         ((⍴⍵)[1]=1)∧(⊃(2⍟(⍴⍵)[2])=⌈2⍟(⍴⍵)[2]): 1    ⍝ We have a bra

--- a/Tests/test_QFT_inverse_001.aplf
+++ b/Tests/test_QFT_inverse_001.aplf
@@ -1,0 +1,19 @@
+test_QFT_inverse_001 ← {
+    ⍝ Test if application of QFT twice is the identity, up to a swap
+
+    ⍝ Random point inside the unit circle
+    random_point ← {(1000÷⍨?1000)×(*(0J1×(○2)×3600÷⍨?3600))}
+
+    ⍝ Generate sample 8-qubit quantum state
+    random_vector ← {#.quapl.mlt.normalize (256 1)⍴random_point¨⍳256}
+
+
+    input ← random_vector¨ ⍳50
+
+    result ← (⊂⊂1,1+⌽⍳255)⌷¨ #.quapl._r_¨ #.quapl.lib._QFT_¨ #.quapl.lib._QFT_¨ input
+    
+    
+    ⍝ Check if sum of differences between input and result rounds to 0
+    'Application of QFT twice is the identity, up to a swap'⊢ (⊃#.quapl._r_ +/[1]⊃+/input-result) Assert 0:
+    ''
+}

--- a/Tests/test_QFT_value_001.aplf
+++ b/Tests/test_QFT_value_001.aplf
@@ -1,0 +1,9 @@
+test_QFT_value_001 ← {
+    ⍝ Testing QFT for up to 8 qubits
+    input ← #.quapl.circuit.thread_reg¨ #.quapl.circuit.reg¨ ⍳8
+    result ← ∊ ∪¨ #.quapl.lib._QFT_¨ input
+    correct_result ← 2*2÷⍨-⍳8
+
+    'Quantum Fourier Transform of |0> is constant 1/2*(n_qubits÷2)'⊢ correct_result Assert result:
+    ''
+}

--- a/Tests/test_QFT_value_002.aplf
+++ b/Tests/test_QFT_value_002.aplf
@@ -1,0 +1,12 @@
+test_QFT_value_002 ← {
+    ⍝ Testing QFT for up to 6 qubits
+    ⍝ Create all basis states for up to 6 qubits
+    input ← {(((,∘1)(⍴⊢))⍴⊢)¨↓↑1,⍨¨0/⍨¨1-⍨⍳⍵}¨2*⍳6
+    result ← #.quapl._r_¨¨ ,¨¨ #.quapl.lib._QFT_¨¨ input
+    correct_function ← {(2*(-⍺÷2))×*(0J1×2×(⍵-1)×○⍤⊢)¨(2*⍺)÷⍨1-⍨⍳(2*⍺)}
+    correct_result ← #.quapl._r_¨¨ (⍳6)correct_function¨¨(⍳¨2*⍳6)
+    
+    ⍝ Check if different is zero up to rounding
+    'Quantum Fourier Transform of basis state |j> is (2*(-n_qubits÷2))×*(0J1)×⍵×j'⊢ (⊃∪#.quapl._r_¨¨∊correct_result-result) Assert 0:
+    ''
+}

--- a/Tests/test_QFT_value_002.aplf
+++ b/Tests/test_QFT_value_002.aplf
@@ -1,7 +1,7 @@
 test_QFT_value_002 ← {
     ⍝ Testing QFT for up to 6 qubits
     ⍝ Create all basis states for up to 6 qubits
-    input ← {(((,∘1)(⍴⊢))⍴⊢)¨↓↑1,⍨¨0/⍨¨1-⍨⍳⍵}¨2*⍳6
+    input ← {{((⍴⍵),1)⍴⍵}¨↓↑1,⍨¨0/⍨¨1-⍨⍳⍵}¨2*⍳6
     result ← #.quapl._r_¨¨ ,¨¨ #.quapl.lib._QFT_¨¨ input
     correct_function ← {(2*(-⍺÷2))×*(0J1×2×(⍵-1)×○⍤⊢)¨(2*⍺)÷⍨1-⍨⍳(2*⍺)}
     correct_result ← #.quapl._r_¨¨ (⍳6)correct_function¨¨(⍳¨2*⍳6)


### PR DESCRIPTION
Implemented the quantum fourier transform using a function to create the very similar parts of the circuit which affect each qubit, then successive staging them. Some code has been reused from the implementation of the Deutsch–Jozsa algorithm, specifically the "apply" function.

Some tests have also been written to verify the value of simple cases, and that the quantum fourier transform is its own inverse up to a reversal.