### PR TITLE
Implement Bernstein-Vazirani algorithm

### DIFF
--- a/APLSource/lib/oracles/BV.aplf
+++ b/APLSource/lib/oracles/BV.aplf
@@ -1,0 +1,7 @@
+BV ← {
+    ⍝ Bernstein-Vazirani oracle
+    ⍝ Takes the inner product of the secret bit vector ⍺ with the input bit vector ⍵
+    ⍝ The first item in the register should be ancilla qubit (typically in the state |->)
+    
+    ⊃ #.quapl.circuit.stage / (((⍸⍺),¨0){⍺ (⊂⍵)}¨⊂#.quapl.gates.CNOT),⊂⍵
+}

--- a/Tests/test_BV_value_001.aplf
+++ b/Tests/test_BV_value_001.aplf
@@ -1,0 +1,23 @@
+test_BV_value_001 ← {
+    ⍝ Generate all possible 5 bit secret vectors
+    secrets ← 5(↑⍨∘-⍨)¨(2∘⊥⍣¯1)¨⍳1-⍨2*5
+    
+    ⍝ From bit vector to qubit state
+    ⍝ For example, takes 0 1 0 1 to |0101>
+    state ← {n ← ⊃⍴⍵ ⋄ (⍪(⍳n)-1),(⍪((#.quapl.sng.q0 (#.quapl.sng.q1))[⍵+1]))}
+
+    ⍝ Generate all possible pure input states up to 6 bits, where the first qubit is in state is |0>
+    vectors ← #.quapl.circuit.thread_reg¨ state¨ 0,[1]¨secrets
+
+    ⍝ All possible applications of secret vectors and input vectors 
+    results ← secrets (∘.(#.quapl.lib.oracles.BV)) vectors
+
+    ⍝ Get ancilla qubits and turn them into bits
+    results ← {#.quapl.sng.q1≡⊃⍵[1;2]}¨¨#.quapl.circuit.unthread_vs¨¨results
+
+    ⍝ Check if result is equivalent to classical bitwise dot product
+    results_correct ← secrets (∘.(≠.×)) secrets
+
+    'Bernstein-Vazirani oracle should return the bitwise dot product of the secret and input vectors'⊢ results_correct Assert results:
+    ''
+}

--- a/Tests/test_BV_value_002.aplf
+++ b/Tests/test_BV_value_002.aplf
@@ -1,0 +1,21 @@
+test_BV_value_002 ← {
+    ⍝ Test if the Bernstein-Vazirani algorithm can recover the secret bit vector for 5 bits
+
+    ⍝ Generate all possible 5 bit secret vectors
+    secrets ← 5(↑⍨∘-⍨)¨(2∘⊥⍣¯1)¨⍳1-⍨2*5
+    
+    ⍝ Generate input state
+    input ← #.quapl.circuit.reg 6
+
+    ⍝ Apply Deutsch-Jozsa algorithm with the Bernstein-Vazirani oracle for each secret bit vector
+    results ← ⍉1↓⍉ ⊃ #.quapl._r_¨¨ {(⍵),((⍺∘#.quapl.lib.oracles.BV)#.quapl.lib._DJ_)(⊃⍵)}/secrets,⊂⊂#.quapl.circuit.thread_reg input
+
+    ⍝ Get the input qubits and turn them into bits
+    results ← ⌽(⊂⍤1)({(⊂#.quapl.sng.q1)≡¨(1↓⍵[;2])}⍤2)(#.quapl.circuit.unthread_vs⍤1)⍉results
+
+
+    'Bernstein-Vazirani algorithm should return the secret bit vector'⊢ secrets Assert results:
+    ''
+
+
+}


### PR DESCRIPTION
Closes #48 

The code for the Bernstein-Vazirani algorithm would be identical to the Deutsch-Jozsa algorithm, except for the use of a oracle. I was unsure of how to structure this, I implemented the oracle under lib.oracles.BV to be used with the lib._DJ_ operator. 

Two tests have been written, the first verifying that the oracle takes the bitwise dot product correctly, and the second tests verifies that the algorithm returns the secret bit vector.