### PR TITLE
Add tests for the Deutsch-Jozsa algorithm

### DIFF
--- a/APLSource/lib/oracles/DJ.apln
+++ b/APLSource/lib/oracles/DJ.apln
@@ -11,17 +11,9 @@
 
       XOR ← {
           n_qubits ← (2⍟1⌷⍴⍵)-1
-     
-          apply ← {
-              ⍝ Recursive function that applies an XOR gate from all qubits into the ancilla.
-              ⍝ Ancilla should be in the index 0.
-              x ← 1↑⍺
-              a ← 1↓⍺
-              ret ← (((⊃x)0) (⊂#.quapl.gates.CNOT)) #.quapl.circuit.stage ⍵
-              (⍴a)=0: ret
-              a ∇ ret
-          }
-          (⍳n_qubits) apply ⍵
+          
+          ⍝ Applies an XOR gate from all qubits into the ancilla
+          ⊃ #.quapl.circuit.stage / (((⍳n_qubits),¨0){⍺ (⊂⍵)}¨⊂#.quapl.gates.CNOT),⊂⍵
       }
 
 :EndNamespace

--- a/APLSource/mlt.apln
+++ b/APLSource/mlt.apln
@@ -5,7 +5,7 @@
     normalize ← {⍵÷0.5*⍨(dagger+.×⊢)⍵}
 
     ⍝ Create all basis states for ⍵ qubits
-    basis ← {{((⍴⍵),1)⍴⍵}¨↓↑1,⍨¨0/⍨¨1-⍨⍳⍵}
+    basis ← {⍪¨↓↑1,⍨¨0/⍨¨1-⍨⍳2*⍵}
 
     ⍝ Test that we have a valid qubit
     valid ← {

--- a/Tests/test_DJ_oracle_XOR_value_001.aplf
+++ b/Tests/test_DJ_oracle_XOR_value_001.aplf
@@ -1,0 +1,24 @@
+test_DJ_oracle_XOR_value_001 ← {
+    ⍝ Test if the XOR oracle returns the correct value for 6 bits
+
+    ⍝ From bit vector to qubit state
+    ⍝ For example, takes 0 1 0 1 to |0101>
+    state ← {n ← ⊃⍴⍵ ⋄ (⍪(⍳n)-1),(⍪((#.quapl.sng.q0 (#.quapl.sng.q1))[⍵+1]))}
+
+    input ← 5(↑⍨∘-⍨)¨(2∘⊥⍣¯1)¨⍳1-⍨2*5
+
+    ⍝ Generate all possible pure input states up to 6 bits, where the first qubit is in state is |0>
+    vectors ← #.quapl.circuit.thread_reg¨ state¨ 0,[1]¨ input
+
+    ⍝ Apply XOR oracle to all input states
+    results ← (#.quapl.lib.oracles.DJ.XOR)¨vectors
+    
+    ⍝ Get the input qubits and turn them into bits
+    results ← {#.quapl.sng.q1≡⊃⍵[1;2]}¨#.quapl.circuit.unthread_vs¨results
+
+    ⍝ Check if result is equivalent to classical bitwise XOR
+    results_correct ← ≠/¨input
+
+    'XOR oracle should return the bitwise XOR of the input vector'⊢ results_correct Assert results:
+    ''
+}

--- a/Tests/test_DJ_value_001.aplf
+++ b/Tests/test_DJ_value_001.aplf
@@ -1,0 +1,18 @@
+test_DJ_value_001 ← {
+    ⍝ Test if the Deutsch-Jozsa algorithm can determine if the function is constant or balanced for 6 bits
+
+    ⍝ Generate input state
+    input ← #.quapl.circuit.thread_reg #.quapl.circuit.reg 6
+
+    ⍝ Apply Deutsch-Jozsa algorithm with the XOR oracle
+    result_XOR ← ⊃((#.quapl.lib.oracles.DJ.XOR)#.quapl.lib._DJ_) input
+
+    ⍝ Apply Deutsch-Jozsa algorithm with the zero oracle
+    results_zero ← ⊃((#.quapl.lib.oracles.DJ.zero)#.quapl.lib._DJ_) input
+
+
+    'Deutsch-Jozsa algorithm should determine if a function is constant or balanced'⊢ (result_XOR results_zero) Assert (0 1):
+    ''
+
+
+}


### PR DESCRIPTION
Closes #59 

Adds a simple test to the Deutsch-Jozsa implementation to verify that it can distinguish between a constant function and a balanced function for the current oracles, and a test for the XOR oracle to verify it returns the correct values.

The XOR oracle was also rewritten to use reduce instead of recursion.